### PR TITLE
Add gator encounter with stateful actions

### DIFF
--- a/game.py
+++ b/game.py
@@ -1,9 +1,24 @@
 class Scene:
     """A single location in the game world."""
-    def __init__(self, name, description, choices):
+
+    def __init__(self, name, description, choices, on_enter=None):
         self.name = name
         self.description = description
-        self.choices = choices  # mapping of command -> next scene name
+        # mapping of command -> next scene name or callable
+        self.choices = choices
+        # optional function called when the scene is entered
+        self.on_enter = on_enter or (lambda state: None)
+
+    def perform_action(self, command, state):
+        """Run an action for the given command if available."""
+        if command in self.choices:
+            action = self.choices[command]
+            if callable(action):
+                result = action(state)
+            else:
+                result = action
+            return True, result
+        return False, None
 
 
 class GameState:
@@ -16,12 +31,42 @@ class GameState:
             "Bag of gator jerky",
         ]
         self.flags = {}
+        # run the starting scene's enter hook
+        self.current_scene.on_enter(self)
 
     def move_to(self, scene_name):
         self.current_scene = self.scenes[scene_name]
+        self.current_scene.on_enter(self)
 
 
 def create_scenes():
+    """Build all scenes and their behaviors."""
+
+    def show_inventory(state):
+        print("Travis checks his pockets:")
+        for item in state.inventory:
+            print(f"- {item}")
+
+    def dirt_road_enter(state):
+        if not state.flags.get("saw_gator"):
+            print(
+                "A mysterious gator crawls from the ditch, gives Travis a wink, "
+                "and coughs up a shiny tooth before disappearing back into the mud."
+            )
+            state.flags["saw_gator"] = True
+            state.flags["tooth_on_ground"] = True
+
+    def pick_up_tooth(state):
+        if state.flags.get("tooth_on_ground"):
+            print(
+                "Travis snatches the Mysterious Gator Tooth. Probably cursed, "
+                "definitely awesome."
+            )
+            state.inventory.append("Mysterious Gator Tooth")
+            state.flags["tooth_on_ground"] = False
+        else:
+            print("There ain't no tooth lyin' around here.")
+
     trailer = Scene(
         "trailer",
         (
@@ -32,6 +77,7 @@ def create_scenes():
         {
             "step outside": "dirt_road",
             "leave": "dirt_road",
+            "inventory": show_inventory,
         },
     )
 
@@ -44,7 +90,10 @@ def create_scenes():
         {
             "go back": "trailer",
             "return": "trailer",
+            "pick up tooth": pick_up_tooth,
+            "inventory": show_inventory,
         },
+        on_enter=dirt_road_enter,
     )
 
     return {scene.name: scene for scene in [trailer, dirt_road]}
@@ -65,11 +114,11 @@ def main():
             print("Even swamp gods need their beauty rest. Later, gator!")
             break
 
-        next_scene = scene.choices.get(choice)
-        if next_scene:
-            state.move_to(next_scene)
-        else:
+        handled, next_scene = scene.perform_action(choice, state)
+        if not handled:
             print("Travis scratches his head, wonderin' what that even means.")
+        elif next_scene:
+            state.move_to(next_scene)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand `Scene` with hooks and actions that can change game state
- trigger a one-time mysterious gator encounter on the dirt road
- allow picking up a **Mysterious Gator Tooth**
- add inventory command to review items

## Testing
- `python3 -m py_compile game.py Travis_Vaelen/main.py intro.py`
- `python3 game.py <<'EOF'
step outside
pick up tooth
go back
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68756515bf98832eb54b5ab641c243af