### PR TITLE
Print available commands before prompt

### DIFF
--- a/Travis_Vaelen/game.py
+++ b/Travis_Vaelen/game.py
@@ -59,6 +59,9 @@ def main():
         scene = state.current_scene
         print(f"\n=== {scene.name.upper()} ===")
         print(scene.description)
+        commands = ", ".join(scene.choices.keys())
+        if commands:
+            print(f"\U0001F40A Available commands: {commands}")
         choice = input("What now? ").strip().lower()
 
         if choice == "quit":

--- a/game.py
+++ b/game.py
@@ -147,6 +147,9 @@ def main():
         scene = state.current_scene
         print(f"\n=== {scene.name.upper()} ===")
         print(scene.description)
+        commands = ", ".join(scene.choices.keys())
+        if commands:
+            print(f"\U0001F40A Available commands: {commands}")
         choice = input("What now? ").strip().lower()
 
         if choice == "quit":


### PR DESCRIPTION
## Summary
- improve visibility of player options
- show available commands in each scene right before the `What now?` prompt

## Testing
- `python -m py_compile game.py Travis_Vaelen/game.py`

------
https://chatgpt.com/codex/tasks/task_e_68757b36c3ac832e9eb46f48d06fe989