### PR TITLE
Improve scene command display and add mirror interaction

### DIFF
--- a/game.py
+++ b/game.py
@@ -67,6 +67,14 @@ def create_scenes():
         else:
             print("There ain't no tooth lyin' around here.")
 
+    def look_in_mirror(state):
+        print("A golden mullet, gleaming like sunrise on the Suwannee")
+        print("Pit Viper sunglasses and a mustache sharp enough to slice jerky")
+        print(
+            "A flamingo tattoo on his right bicep with the words \u201cSaeva Venia\u201d inked beneath it"
+        )
+        print("A lat spread so glorious, it was carved by ancient fanboat spirits")
+
     trailer = Scene(
         "trailer",
         (
@@ -78,6 +86,7 @@ def create_scenes():
             "step outside": "dirt_road",
             "leave": "dirt_road",
             "inventory": show_inventory,
+            "look in mirror": look_in_mirror,
         },
     )
 
@@ -147,9 +156,9 @@ def main():
         scene = state.current_scene
         print(f"\n=== {scene.name.upper()} ===")
         print(scene.description)
-        commands = ", ".join(scene.choices.keys())
-        if commands:
-            print(f"\U0001F40A Available commands: {commands}")
+        print("What now? You can:")
+        for cmd in scene.choices:
+            print(f"- {cmd}")
         choice = input("What now? ").strip().lower()
 
         if choice == "quit":


### PR DESCRIPTION
## Summary
- add a new `look_in_mirror` action for the trailer scene
- show commands as a bullet list whenever a scene is entered

## Testing
- `python3 -m py_compile game.py`
- `python3 game.py <<'EOF'
quit
EOF`
- `python3 game.py <<'EOF'
step outside
quit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68757f55cf88832ea657eff00417b902