### PR TITLE
Fix unicode print issue in game.py

### DIFF
--- a/game.py
+++ b/game.py
@@ -116,7 +116,7 @@ def create_scenes():
             "read note": lambda state: print(
                 "The note is written in lipstick on crumpled receipt paper. It reads:\n\n"
                 '\"Memorial Day. Ginnie Springs. Bring the ducky float, the shine, and that sinful tongue. I\u2019ll be waiting.\"\n\n'
-                "- Saeva \ud83d\udc8b"
+                "- Saeva \U0001F48B"
             ),
             "look in mirror": look_in_mirror,
             "inventory": show_inventory,


### PR DESCRIPTION
## Summary
- replace invalid surrogate pair with valid emoji codepoint

## Testing
- `python -m py_compile game.py Travis_Vaelen/game.py intro.py Travis_Vaelen/intro.py Travis_Vaelen/entities/travis.py`
- `python game.py <<'EOF'
read note
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6876f4b6ba80832e803235fae0b1c3e4